### PR TITLE
fixed crashing problem

### DIFF
--- a/pytouhou/menu.py
+++ b/pytouhou/menu.py
@@ -15,6 +15,8 @@
 from pytouhou.utils.helpers import get_logger
 logger = get_logger(__name__)
 
+import gi
+gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk, Gdk, GLib
 
 import sys


### PR DESCRIPTION
The game crashed because gi didn't know which version of GTK to import. I'm not a professional Python dev so this code may be completely bogus but it fixes the problem for me